### PR TITLE
Avoid Finder permission dialog

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = async nameOrBundleId => {
 
 	const query = isBundleId ?
 		`kMDItemContentType == 'com.apple.application-bundle' && kMDItemCFBundleIdentifier == '${nameOrBundleId}'` :
-		`kMDItemKind == 'Application' && kMDItemFSName == '${nameOrBundleId}.app'c`;
+		`kMDItemKind == 'Application' && kMDItemFSName == '${nameOrBundleId}.app'`;
 
 	const {stdout: appPath} = await execFileP('mdfind', [query]);
 

--- a/index.js
+++ b/index.js
@@ -1,20 +1,17 @@
 'use strict';
-const runApplescript = require('run-applescript');
+const {execFile} = require('child_process');
+const {promisify} = require('util');
+
+const execFileP = promisify(execFile);
 
 module.exports = async nameOrBundleId => {
-	nameOrBundleId = `"${nameOrBundleId}"`;
-
 	const isBundleId = nameOrBundleId.includes('.');
-	if (!isBundleId) {
-		nameOrBundleId = `(get id of application ${nameOrBundleId})`;
-	}
 
-	const exists = await runApplescript(`
-		try
-			tell application "Finder" to get application file id ${nameOrBundleId}
-			return true
-		end try
-	`);
+	const query = isBundleId ?
+		`kMDItemContentType == 'com.apple.application-bundle' && kMDItemCFBundleIdentifier == '${nameOrBundleId}'` :
+		`kMDItemKind == 'Application' && kMDItemFSName == '${nameOrBundleId}.app'c`;
 
-	return exists === 'true';
+	const {stdout: appPath} = await execFileP('mdfind', [query]);
+
+	return Boolean(appPath);
 };

--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
 		"bundleid",
 		"id"
 	],
-	"dependencies": {
-		"run-applescript": "^3.1.0"
-	},
 	"devDependencies": {
 		"ava": "^2.2.0",
 		"tsd": "^0.7.4",


### PR DESCRIPTION
Uses mdfind to locate apps rather than AppleScript asking Finder.

Closes #1 