### PR TITLE
Only include apps in the default app directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,12 +5,17 @@ const execFileP = promisify(execFile);
 
 export default async function appExists(nameOrBundleId) {
 	const isBundleId = nameOrBundleId.includes('.');
+	const paths = [
+		'/Applications',
+		'~/Applications'
+	];
+	const pathArgs = paths.map(path => ['-onlyin', path]).flat();
 
 	const query = isBundleId ?
 		`kMDItemContentType == 'com.apple.application-bundle' && kMDItemCFBundleIdentifier == '${nameOrBundleId}'` :
 		`kMDItemKind == 'Application' && kMDItemFSName == '${nameOrBundleId}.app'`;
 
-	const {stdout: appPath} = await execFileP('mdfind', [query]);
+	const {stdout: appPath} = await execFileP('mdfind', [query, ...pathArgs]);
 
 	return Boolean(appPath);
 }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ export default async function appExists(nameOrBundleId) {
 		'/Applications',
 		'~/Applications'
 	];
-	const pathArgs = paths.map(path => ['-onlyin', path]).flat();
+	const pathArgs = paths.flatMap(path => ['-onlyin', path]);
 
 	const query = isBundleId ?
 		`kMDItemContentType == 'com.apple.application-bundle' && kMDItemCFBundleIdentifier == '${nameOrBundleId}'` :


### PR DESCRIPTION
When Time Machine backups are connected `mdfind` list paths from the time machine backups. If the app has been uninstalled in the past and its backup exists, the `app-exists` return `true`.