### PR TITLE
Fix local applications folder path using a tilde

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ export default async function appExists(nameOrBundleId) {
 	const isBundleId = nameOrBundleId.includes('.');
 	const paths = [
 		'/Applications',
-		'~/Applications'
+                process.env.HOME + '/Applications'
 	];
 	const pathArgs = paths.flatMap(path => ['-onlyin', path]);
 


### PR DESCRIPTION
node.js does not expand tildes (nodejs/node#684)
Fixes #5.
I'm not a node developer, there may be a nicer way of concatenating the 2 strings than I am aware of.

Edit: sorry I didn't read the contributing.md document fully at first, I've changed Closes to Fixes. Please let me know if I've missed anything, I'm still learning.